### PR TITLE
fix invalid option pass through

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,7 +9,7 @@ ifneq ("@IMLIB2_CONFIG@","")
     IMLIB2_LIBS=`@IMLIB2_CONFIG@ --libs`
 endif
 ifneq ("@WAND_CONFIG@","")
-    WAND_INCLUDES=`@WAND_CONFIG@ --cppflags`
+    WAND_INCLUDES=`@WAND_CONFIG@ --cppflags | sed -e s/-fopenmp/-Wc,-fopenmp/`
     WAND_LIBS=`@WAND_CONFIG@ --libs`
 endif
 CFLAGS=@CFLAGS_IMLIB2@ @CFLAGS_WAND@ @CFLAGS_JPEG@


### PR DESCRIPTION
In my environment, building mod_small_light fails.
## environment
- Debian7.0
- GCC 4.7.2
- Apache 2.2.22
- ImageMagick 6.7.7
- Imlib2 1.4.5

``` sh
$ ./configure --with-apxs=/usr/sbin/apxs2
$ make
/usr/bin/apxs2 -c -DENABLE_IMLIB2 -DENABLE_WAND -DENABLE_JPEG -ljpeg `/usr/bin/imlib2-config --cflags` `/usr/bin/imlib2-config --libs` `/usr/bin/Wand-config --cppflags` `/usr/bin/Wand-config --libs` \
        mod_small_light.c mod_small_light_*.c
Use of uninitialized value $includedir in concatenation (.) or string at (eval 9) line 1.
apxs:Error: Unknown option: f.
Usage: apxs -g [-S <var>=<val>] -n <modname>
       apxs -q [-S <var>=<val>] <query> ...
       apxs -c [-S <var>=<val>] [-o <dsofile>] [-D <name>[=<value>]]
               [-I <incdir>] [-L <libdir>] [-l <libname>] [-Wc,<flags>]
               [-Wl,<flags>] [-p] <files> ...
       apxs -i [-S <var>=<val>] [-a] [-A] [-n <modname>] <dsofile> ...
       apxs -e [-S <var>=<val>] [-a] [-A] [-n <modname>] <dsofile> ...
make: *** [all] エラー 1
$
```

The cause is the output of `Wand-config --cflags`.

``` sh
$ Wand-config --cflags
-fopenmp -I/usr/include/ImageMagick
$
```

apxs can not recognize '-f' and can not receive '-fopenmp' really.
It is necessary to use '-Wc' to give argument to apxs.

FYI, `Wand-config --cflags` of old ImageMagick(for example, v6.6.0) outputs following.

``` sh
-I/usr/include/ImageMagick -fopenmp
```

In this case, '-fopenmp' is ignored by apxs.
