### PR TITLE
Fixed the method of detecting whether is threaded

### DIFF
--- a/mod_small_light.c
+++ b/mod_small_light.c
@@ -93,7 +93,7 @@ static int small_light_post_config(
 {
 #if APR_HAS_THREADS
     int mpm_threads;
-    ap_mpm_query(AP_MPMQ_MAX_THREADS, &mpm_threads);
+    ap_mpm_query(AP_MPMQ_IS_THREADED, &mpm_threads);
     if (mpm_threads >= 1) {
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s,
             "small_light module only works with mpm prefork mode"


### PR DESCRIPTION
ApacheのMPMの判定部分を修正しました。

apache 2.4においてprefork/workerの判定部分にエラーがありpreforkでもmake installが失敗する問題を修正したものになります。

https://qiita.com/sarumonera/items/7e3b517993aa205d2fd3